### PR TITLE
Add style to fix scrolling issue inside DataTable

### DIFF
--- a/src/components/MovieList.js
+++ b/src/components/MovieList.js
@@ -6,10 +6,13 @@ import { DataTable, TableHeader, TableBody, TableRow, TableColumn, Button } from
 import { MovieListRow } from './MovieListRow';
 import Page from './Page'
 
+const dataTableStyle = {
+  'margin-bottom': '36px'
+};
 
 export const MovieList = ({data, onDelete}) => (
     <Page>
-        <DataTable plain>
+        <DataTable plain style={dataTableStyle}>
             <TableHeader>
                 <TableRow>
                     <TableColumn></TableColumn>


### PR DESCRIPTION
Last element (row) inside DataTable is currently cut off by the footer. As changing the footer to a relative position to fix this issue would introduce unwanted behavior on other pages, a simple fix is hereby proposed directly inside the MovieList component through the addition of the style attribute.